### PR TITLE
Define "dlt" resource in its own dg.Definitions object within "defs/resource"

### DIFF
--- a/pokemon_dagster_dlt/definitions.py
+++ b/pokemon_dagster_dlt/definitions.py
@@ -2,12 +2,5 @@ from pathlib import Path
 
 import pokemon_dagster_dlt.defs
 from dagster_components import load_defs
-from pokemon_dagster_dlt.defs import resources
 
-
-defs = load_defs(
-    defs_root=pokemon_dagster_dlt.defs,
-    resources={
-        "dlt": resources.dlt_resource
-    },    
-)
+defs = load_defs(defs_root=pokemon_dagster_dlt.defs)

--- a/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
@@ -1,85 +1,52 @@
 """
 This example uses the dagster-dlt library within the Dagster framework (official integration) to materialize
 multi-assets from 3 endpoints of a single REST API source.
-
-This example may have a bug. The "dlt" resource specified in pokemon_dagster_dlt/definitions.py is not being 
-recognized. View comments at the bottom for more detail.
 """
 
-# import dagster as dg
-# import dlt
-# from dlt.extract.resource import DltResource
-# from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
-# from dlt.sources.rest_api import rest_api_source
-# from collections.abc import Iterable
+import dagster as dg
+import dlt
+from dlt.extract.resource import DltResource
+from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
+from dlt.sources.rest_api import rest_api_source
+from collections.abc import Iterable
 
-# pokemon_source = rest_api_source(
-#     {
-#         "client": {"base_url": "https://pokeapi.co/api/v2/"},
-#         "resource_defaults": {
-#             "endpoint": {
-#                 "params": {
-#                     "limit": 1000,
-#                 },
-#             },
-#         },
-#         "resources": [
-#             "pokemon",
-#             "berry",
-#             "location",
-#         ],
-#     }
-# )
-
-# class CustomDagsterDltTranslator(DagsterDltTranslator):
-#      def get_asset_key(self, resource: DltResource) -> dg.AssetKey:
-#          """Overrides asset key to be the dlt resource name with a 'pokemon' prefix."""
-#          return dg.AssetKey(f"{resource.name}").with_prefix("poke_api_2")
-
-#      def get_deps_asset_keys(self, resource: DltResource) -> Iterable[dg.AssetKey]:
-#          """Overrides upstream asset key to be a single source asset."""
-#          return []
-
-# @dlt_assets(
-#     dlt_source=pokemon_source,
-#     dlt_pipeline=dlt.pipeline(
-#         pipeline_name="example_2",
-#         dataset_name="poke_rest_api_2",
-#         destination="duckdb",
-#     ),
-#     group_name="dltHub__github_2",
-#     dagster_dlt_translator=CustomDagsterDltTranslator(),
-# )
-
-# def load_pokemon_2(context: dg.AssetExecutionContext, dlt: DagsterDltResource):
-#     yield from dlt.run(context=context)
-
-"""
-Running `dg check defs`:
-
-------------------------
-
-2025-03-29 14:55:29 -0700 - dagster - ERROR - Validation failed for code location pokemon-dagster-dlt:
-
-dagster._core.errors.DagsterInvalidDefinitionError: resource with key 'dlt' required by op 'load_pokemon_2' was not provided. Please provide a ResourceDefinition to key 'dlt', or change the required key to one of the following keys which points to an ResourceDefinition: ['io_manager']
-
-Stack Trace:
-  [15 dagster system frames hidden, run with --verbose to see the full stack trace]
-
-2025-03-29 14:55:29 -0700 - dagster - ERROR - Validation for 1 code locations failed.
-
-------------------------
-
-This error comes up even though "dlt" is defined in defs/resources/__init__.py and imported into the defs object.
-
-in defs/definitions.py:
-
-defs = load_defs(
-    defs_root=pokemon_dagster_dlt.defs,
-    resources={
-        "dlt": resources.dlt_resource
-    },    
+pokemon_source = rest_api_source(
+    {
+        "client": {"base_url": "https://pokeapi.co/api/v2/"},
+        "resource_defaults": {
+            "endpoint": {
+                "params": {
+                    "limit": 1000,
+                },
+            },
+        },
+        "resources": [
+            "pokemon",
+            "berry",
+            "location",
+        ],
+    }
 )
 
-This follows the docs and works fine using the latest dagster library (not dg CLI).
-"""
+class CustomDagsterDltTranslator(DagsterDltTranslator):
+     def get_asset_key(self, resource: DltResource) -> dg.AssetKey:
+         """Overrides asset key to be the dlt resource name with a 'pokemon' prefix."""
+         return dg.AssetKey(f"{resource.name}").with_prefix("poke_api_2")
+
+     def get_deps_asset_keys(self, resource: DltResource) -> Iterable[dg.AssetKey]:
+         """Overrides upstream asset key to be a single source asset."""
+         return []
+
+@dlt_assets(
+    dlt_source=pokemon_source,
+    dlt_pipeline=dlt.pipeline(
+        pipeline_name="example_2",
+        dataset_name="poke_rest_api_2",
+        destination="duckdb",
+    ),
+    group_name="dltHub__github_2",
+    dagster_dlt_translator=CustomDagsterDltTranslator(),
+)
+
+def load_pokemon_2(context: dg.AssetExecutionContext, dlt: DagsterDltResource):
+    yield from dlt.run(context=context)

--- a/pokemon_dagster_dlt/defs/resources/__init__.py
+++ b/pokemon_dagster_dlt/defs/resources/__init__.py
@@ -1,3 +1,4 @@
+import dagster as dg
 from dagster_dlt import DagsterDltResource
 
-dlt_resource = DagsterDltResource()
+defs = dg.Definitions(resources={"dlt": DagsterDltResource()})


### PR DESCRIPTION
# Summary
So far, I've been working on building examples of building multi-asset materializations using the new `dg` CLI and the official `dagster-dlt` library.

In this repo, I plan on making three examples for a future write-up under `defs/assets/`:
1. `1_poke_rest_api.py` : Using the `dlt` raw declarative REST API source interface, wrapped with dg's `@multi-asset`
    - Minimum example from dltHub wrapped with Dagster
2. `2_poke_rest_api.py`: Using the embedded `dagster-dlt` integration
    - This is to get a feel for the ergonimics of `dagster-dlt` in comparison to the 1st and 2nd example
3. `3_poke_rest_api.py`: Using `dlt` and `dg` with my personal preferred scaffolding/code flow
    - This example would serve as my personal preferred way to combine `dg` and `dlt` to materailize multi-assets

As I was working on the 2nd example, I came across a [problem](https://github.com/jairus-m/pokemon-dagster-dlt/commit/1366971b3fd930db1c71ff28ee76c302702fe2f6) with configuring and using a Dagster resource defintiion with dlt. This PR addresses this issue as advised by @schrockn.

# Details

Based on [this](https://github.com/dagster-io/dagster/discussions/28472#discussioncomment-12664653), I think the issue is mostly because I was trying to use the top-level Dagster definitions object in the same way that you would in the previous iteration of Dagster where you have to explicitly import all the Definitions objects into the final, top-level `dg.Definitions`. 

The change suggested was to instead create a resource-specific `dg.Definitions` object in `defs/resource/__init__.py` so that it could be auto-detected by the top-level `load_defs` function in `definitions.py`. 

Therefore as Nick said, instead of this in `defs/resource/__init__.py`:

```python
from dagster_dlt import DagsterDltResource

dlt_resource = DagsterDltResource()
```

I should instead have:

```python
import dagster as dg
from dagster_dlt import DagsterDltResource

defs = dg.Definitions(resources={"dlt_resource": DagsterDltResource()})
```

which will keep the top-level `definitions.py` as the original scaffolded code:

```python
import pokemon_dagster_dlt.defs
from dagster_components import load_defs

defs = load_defs(
    defs_root=pokemon_dagster_dlt..defs,    
)
```