### PR TITLE
Add 3rd dlt + Dagster example

### DIFF
--- a/pokemon_dagster_dlt/defs/assets/dlt/1_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/1_poke_rest_api.py
@@ -40,7 +40,7 @@ from dlt.sources.rest_api import rest_api_source
 )
 def load_pokemon_1():
     pipeline = dlt.pipeline(
-        pipeline_name="rest_api_pokemon",
+        pipeline_name="rest_api_pokemon_1", # .duckdb file named after pipeline
         destination="duckdb",
         dataset_name="poke_rest_api_1",
     )

--- a/pokemon_dagster_dlt/defs/assets/dlt/1_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/1_poke_rest_api.py
@@ -35,7 +35,7 @@ from dlt.sources.rest_api import rest_api_source
             description="Locations that exist within Pokemon games",
         ),
     },
-    group_name="dltHub__github_1",
+    group_name="dltHub__poke_1",
     compute_kind="dlt",
 )
 def load_pokemon_1():

--- a/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
@@ -44,7 +44,7 @@ class CustomDagsterDltTranslator(DagsterDltTranslator):
         dataset_name="poke_rest_api_2",
         destination="duckdb",
     ),
-    group_name="dltHub__github_2",
+    group_name="dltHub__poke_2",
     dagster_dlt_translator=CustomDagsterDltTranslator(),
 )
 

--- a/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/2_poke_rest_api.py
@@ -40,7 +40,7 @@ class CustomDagsterDltTranslator(DagsterDltTranslator):
 @dlt_assets(
     dlt_source=pokemon_source,
     dlt_pipeline=dlt.pipeline(
-        pipeline_name="example_2",
+        pipeline_name="rest_api_pokemon_2", # .duckdb file named after pipeline
         dataset_name="poke_rest_api_2",
         destination="duckdb",
     ),

--- a/pokemon_dagster_dlt/defs/assets/dlt/3_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/3_poke_rest_api.py
@@ -1,0 +1,96 @@
+import dagster as dg
+import dlt
+import requests
+@dlt.resource
+def pokemon_resource():
+    """
+    A dlt resource to extract data from the Pokemon REST API.
+    This function fetches data from the Pokemon endpoint and yields the response.
+    Args:
+        None
+    Yields:
+        Generator: Yields the response object from the Pokemon REST API.
+    """
+    url = "https://pokeapi.co/api/v2/pokemon"
+    response = requests.get(url)
+    response.raise_for_status()
+    yield response.json()
+@dlt.resource
+def berry_resource():
+    """
+    A dlt resource to extract data from the Pokemon REST API.
+    This function fetches data from the Berry endpoint and yields the response.
+    Args:
+        None
+    Yields:
+        Generator: Yields the response object from the Pokemon REST API.
+    """
+    url = "https://pokeapi.co/api/v2/berry"
+    response = requests.get(url)
+    response.raise_for_status()
+    yield response.json()
+@dlt.resource
+def location_resource():
+    """
+    A dlt resource to extract data from the Pokemon REST API.
+    This function fetches data from the Location endpoint and yields the response.
+    Args:
+        None
+    Yields:
+        Generator: Yields the response object from the Pokemon REST API.
+    """
+    url = "https://pokeapi.co/api/v2/location"
+    response = requests.get(url)
+    response.raise_for_status()
+    yield response.json()
+@dlt.source
+def pokeapi_source():
+    """
+    A dlt source to combine multiple resources from the Pokemon REST API.
+    """
+    return [
+        pokemon_resource(),
+        berry_resource(),
+        location_resource()
+    ]
+@dg.multi_asset(
+    outs={
+        "pokemon": dg.AssetOut(
+            key=[ # asset key becomes the table name in target DB
+                "poke_api_3",
+                "pokemon_3",
+            ],
+            description="General Pokemon data", # description associated with asset, viewable in Dagster UI
+        ),
+        "berry": dg.AssetOut(
+            key=[
+                "poke_api_3",
+                "berry_3",
+            ],
+            description="Berry data which provide HP and status condition restoration, stat enhancement, and even damage negation when eaten by Pokémon",
+        ),
+        "location": dg.AssetOut(
+            key=[
+                "poke_api_3",
+                "location_3",
+            ],
+            description="Locations that exist within Pokemon games",
+        ),
+    },
+    group_name="dltHub__poke_3",
+    compute_kind="dlt",
+)
+def load_pokemon_data_3():
+    pipeline = dlt.pipeline(
+        pipeline_name="rest_api_pokemon_3",
+        destination="duckdb",
+    )
+    load_info = pipeline.run(pokeapi_source(), dataset_name="poke_rest_api_3", write_disposition='replace',)
+    print(load_info)
+    # when an op is defined to have multiple outputs, Dagster expects the function
+    # to either yield each output individually or return a tuple containing a value for each output
+    return (
+        dg.Output(value=load_info[0]), # returning dlt load_info object corresponding to each resource (pokemon)
+        dg.Output(value=load_info[1]), # berry
+        dg.Output(value=load_info[2]), # location
+    )

--- a/pokemon_dagster_dlt/defs/assets/dlt/3_poke_rest_api.py
+++ b/pokemon_dagster_dlt/defs/assets/dlt/3_poke_rest_api.py
@@ -82,7 +82,7 @@ def pokeapi_source():
 )
 def load_pokemon_data_3():
     pipeline = dlt.pipeline(
-        pipeline_name="rest_api_pokemon_3",
+        pipeline_name="rest_api_pokemon_3", # .duckdb file named after pipeline
         destination="duckdb",
     )
     load_info = pipeline.run(pokeapi_source(), dataset_name="poke_rest_api_3", write_disposition='replace',)


### PR DESCRIPTION
# Summary 

Adding the 3rd dlt + dagster example. This example uses the stand-alone `dlt` library with `dagster-dg`. 

# Details
The main difference here with the past approaches:
- REST API endpoints are organized into `@dlt.resource`'s that yield from the response results 
- These endpoints come together into a single `pokeapi_source` function, wrapped by the `@dlt.source` decorator
- The final `load_pokemon_data_3` functions is wrapped in the `@dg.multi_asset` decorator
  - This allows more explicit control over the:
    - Asset key names
    - Descriptions
    - Compute kinds
    - Etc.  

The first two are more declarative, with `2_poke_rest_api.py` being the most. 
- The second example uses the `dlt-dagster` integration and much of the meta data is implied by Dagster based on the dlt `rest_api_source` config. In addition, because of this, you have to create `CustomDagsterDltTranslator(DagsterDltTranslator)` to modify the behavior of asset metadata.
- The integration does not have an easy way to create asset descriptions

# Validation

#### Ran `dg check defs`
```bash
(pokemon-dagster-dlt) (base) jairusmartinez@Jairuss-MacBook-Pro pokemon-dagster-dlt % dg check defs
All components validated successfully.
Using /Users/jairusmartinez/Desktop/pokemon-dagster-dlt/.venv/bin/dagster
uv run dagster definitions validate --log-level warning --log-format colored --workspace /var/folders/2x/ff9c3jq93jd0gvcs_p8fh_f00000gn/T/tmpp1pqj1cw
All definitions loaded successfully.
```

#### Ran `dg list defs`
```bash
(pokemon-dagster-dlt) (base) jairusmartinez@Jairuss-MacBook-Pro pokemon-dagster-dlt % dg list defs
Using /Users/jairusmartinez/Desktop/pokemon-dagster-dlt/.venv/bin/dagster-components
Assets
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Key                   ┃ Group          ┃ Deps ┃ Kinds  ┃ Description                                                                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ poke_api_1/berry_1    │ dltHub__poke_1 │      │        │ Berry data which provide HP and status condition restoration, stat enhancement, and even    │
│                       │                │      │        │ damage negation when eaten by Pokémon                                                       │
│ poke_api_1/location_1 │ dltHub__poke_1 │      │        │ Locations that exist within Pokemon games                                                   │
│ poke_api_1/pokemon_1  │ dltHub__poke_1 │      │        │ General Pokemon data                                                                        │
│ poke_api_2/berry      │ dltHub__poke_2 │      │ dlt    │                                                                                             │
│                       │                │      │ duckdb │                                                                                             │
│ poke_api_2/location   │ dltHub__poke_2 │      │ dlt    │                                                                                             │
│                       │                │      │ duckdb │                                                                                             │
│ poke_api_2/pokemon    │ dltHub__poke_2 │      │ dlt    │                                                                                             │
│                       │                │      │ duckdb │                                                                                             │
│ poke_api_3/berry_3    │ dltHub__poke_3 │      │        │ Berry data which provide HP and status condition restoration, stat enhancement, and even    │
│                       │                │      │        │ damage negation when eaten by Pokémon                                                       │
│ poke_api_3/location_3 │ dltHub__poke_3 │      │        │ Locations that exist within Pokemon games                                                   │
│ poke_api_3/pokemon_3  │ dltHub__poke_3 │      │        │ General Pokemon data                                                                        │
└───────────────────────┴────────────────┴──────┴────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘

(pokemon-dagster-dlt) (base) jairusmartinez@Jairuss-MacBook-Pro pokemon-dagster-dlt % 
```

#### Materialized All 9 assets:
<img width="1506" alt="Screenshot 2025-04-10 at 8 14 31 PM" src="https://github.com/user-attachments/assets/28036ad1-e751-433e-a2e2-e14c4ad4f4f4" />
